### PR TITLE
chore: rename events and callbacks

### DIFF
--- a/client/menus/main.lua
+++ b/client/menus/main.lua
@@ -77,7 +77,7 @@ local function disableControls()
 end
 
 local function repair()
-    local success = lib.callback.await('customs:server:repair', false, GetVehicleBodyHealth(vehicle))
+    local success = lib.callback.await('qbx_customs:server:repair', false, GetVehicleBodyHealth(vehicle))
     if success then
         exports.qbx_core:Notify(Lang:t('notifications.success.repaired'), 'success')
         SendNUIMessage({sound = true})
@@ -117,10 +117,10 @@ menu.onClose = function()
         icon = 'fa-solid fa-car',
         position = 'left-center',
     })
-    TriggerServerEvent('customs:server:saveVehicleProps')
+    TriggerServerEvent('qbx_customs:server:saveVehicleProps')
 end
 
-lib.callback.register('customs:client:vehicleProps', function()
+lib.callback.register('qbx_customs:client:vehicleProps', function()
     return lib.getVehicleProperties(vehicle)
 end)
 

--- a/client/utils.lua
+++ b/client/utils.lua
@@ -25,7 +25,7 @@ function InstallMod(duplicate, mod, props, level)
         return false
     end
 
-    local success = lib.callback.await('customs:server:pay', false, mod, level)
+    local success = lib.callback.await('qbx_customs:server:pay', false, mod, level)
     if success then
         exports.qbx_core:Notify(
             props?.title or Lang:t('notifications.props.installTitle'),

--- a/client/zones.lua
+++ b/client/zones.lua
@@ -74,6 +74,6 @@ CreateThread(function()
     end
 end)
 
-lib.callback.register('customs:client:zone', function()
+lib.callback.register('qbx_customs:client:zone', function()
     return zoneId
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -29,8 +29,8 @@ local function removeMoney(source, amount)
 end
 
 -- Won't charge money for mods if the player's job is in the list
-lib.callback.register('customs:server:pay', function(source, mod, level)
-    local zone = lib.callback.await('customs:client:zone', source)
+lib.callback.register('qbx_customs:server:pay', function(source, mod, level)
+    local zone = lib.callback.await('qbx_customs:client:zone', source)
 
     for i, v in ipairs(Config.Zones) do
         if i == zone and v.freeMods then
@@ -47,8 +47,8 @@ lib.callback.register('customs:server:pay', function(source, mod, level)
 end)
 
 -- Won't charge money for repairs if the player's job is in the list
-lib.callback.register('customs:server:repair', function(source, bodyHealth)
-    local zone = lib.callback.await('customs:client:zone', source)
+lib.callback.register('qbx_customs:server:repair', function(source, bodyHealth)
+    local zone = lib.callback.await('qbx_customs:client:zone', source)
 
     for i, v in ipairs(Config.Zones) do
         if i == zone and v.freeRepair then
@@ -75,9 +75,9 @@ local function IsVehicleOwned(plate)
 end
 
 --Copied from qb-mechanicjob
-RegisterNetEvent('customs:server:saveVehicleProps', function()
+RegisterNetEvent('qbx_customs:server:saveVehicleProps', function()
     local src = source --[[@as number]]
-    local vehicleProps = lib.callback.await('customs:client:vehicleProps', src)
+    local vehicleProps = lib.callback.await('qbx_customs:client:vehicleProps', src)
     if IsVehicleOwned(vehicleProps.plate) then
         exports.oxmysql.update('UPDATE player_vehicles SET mods = ? WHERE plate = ?', {json.encode(vehicleProps), vehicleProps.plate})
     end


### PR DESCRIPTION
## Description

Rename all the events and callbacks to qbx_customs:

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
