### PR TITLE
fix(client/zones): invalid blip check

### DIFF
--- a/client/zones.lua
+++ b/client/zones.lua
@@ -87,7 +87,7 @@ CreateThread(function()
             end,
         })
 
-        if not v.hideBlip then
+        if not v.hideBlip and v.blip then
             local center = calculatePolyzoneCenter(v.points)
             local blip = AddBlipForCoord(center.x, center.y, center.z)
             SetBlipSprite(blip, v.blip.sprite or 72)


### PR DESCRIPTION
## Description

Fixes the well-known issue that an unchanged qbx_customs will error out because no blips are present in the config.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
