### PR TITLE
fix(livery): Ensure livery options are displayed, ignore stock only

### DIFF
--- a/client/menus/colors.lua
+++ b/client/menus/colors.lua
@@ -222,7 +222,7 @@ local function livery()
     local oldLiveryMethod = GetVehicleLivery(vehicle)
     local newLiveryMethod = GetVehicleMod(vehicle, 48)
 
-    if newLiveryMethod >= 0 or oldLiveryMethod >= 0 then
+    if newLiveryMethod >= 0 or oldLiveryMethod >= -1 then
         originalLivery = {
             index = newLiveryMethod,
             old = false

--- a/client/menus/colors.lua
+++ b/client/menus/colors.lua
@@ -222,7 +222,7 @@ local function livery()
     local oldLiveryMethod = GetVehicleLivery(vehicle)
     local newLiveryMethod = GetVehicleMod(vehicle, 48)
 
-    if newLiveryMethod >= 0 or oldLiveryMethod == -1 then
+    if newLiveryMethod >= 0 or oldLiveryMethod >= 0 then
         originalLivery = {
             index = newLiveryMethod,
             old = false
@@ -237,14 +237,18 @@ local function livery()
     local liveryLabels = {}
     if originalLivery.old then
         local liveryCount = GetVehicleLiveryCount(vehicle) - 1
-        for i = 0, liveryCount do
-            liveryLabels[i + 1] = ('%s %d'):format(locale('menus.options.livery'), i + 1)
+        if liveryCount > -1 then
+            for i = 0, liveryCount do
+                liveryLabels[i + 1] = ('%s %d'):format(locale('menus.options.livery'), i + 1)
+            end
         end
     else
-        liveryLabels[1] = locale('menus.general.stock')
         local liveryCount = GetNumVehicleMods(vehicle, 48) - 1
-        for i = 0, liveryCount do
-            liveryLabels[i + 2] = ('%s'):format(GetLabelText(GetModTextLabel(vehicle, 48, i)))
+        if liveryCount > -1 then
+            liveryLabels[1] = locale('menus.general.stock')
+            for i = 0, liveryCount do
+                liveryLabels[i + 2] = ('%s'):format(GetLabelText(GetModTextLabel(vehicle, 48, i)))
+            end
         end
     end
 


### PR DESCRIPTION
Some vehicles with livery options would not display livery in the colors menu.
(eg. gbpolcomets2r shows nothing, but gbpolrospero does.)
This ensures vehicles that have livery options will be shown, unless the only option is stock, then it is omitted. 

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
