### PR TITLE
fix(menu): prevent crash when performance options are empty

### DIFF
--- a/client/menus/performance.lua
+++ b/client/menus/performance.lua
@@ -130,7 +130,17 @@ menu.onSelected = function(selected)
 end
 
 return function()
-    menu.options = performance()
+    local options = performance()
+
+    if #options == 0 then
+        exports.qbx_core:Notify(locale(
+            'notifications.inform.carNoPerformanceUpgrades'
+        ))
+
+        return mainMenuId
+    end
+
+    menu.options = options
     lib.registerMenu(menu, onSubmit)
     return menu.id
 end

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,7 @@ game 'gta5'
 author 'Jorn#0008'
 description 'qbx_customs'
 repository 'https://github.com/Qbox-project/qbx_customs'
-version '0.1.0'
+version '0.1.1'
 
 ox_lib 'locale'
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -8,6 +8,9 @@
             "money": "You don't have enough money!",
             "alreadyInstalled": "You already have this mod installed"
         },
+        "inform": {
+            "carNoPerformanceUpgrades": "This vehicle has no performance upgrades available"
+        },
         "props": {
             "installTitle": "Customs"
         }


### PR DESCRIPTION
## Description

This PR fixes a crash that occurred when opening the performance upgrade menu on vehicles that do not support performance modifications (such as bicycles).
Previously, the script attempted to register a menu with no options, which caused a runtime error.

## Checklist

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
